### PR TITLE
Release/r type

### DIFF
--- a/include/GameEngine/ecs/Registry.hpp
+++ b/include/GameEngine/ecs/Registry.hpp
@@ -71,6 +71,8 @@ class Registry
 
         std::size_t getEntitiesCount() const;
 
+        void resetEntitiesCount();
+
     private:
         std::unordered_map<std::type_index, std::any> _componentsArrays;
         std::size_t _entitiesCount = 0;

--- a/src/ecs/Registry.cpp
+++ b/src/ecs/Registry.cpp
@@ -64,6 +64,15 @@ std::size_t Registry::getEntitiesCount() const
 }
 
 /**
+ * @brief Reset the entities count to zero
+ *
+ */
+void Registry::resetEntitiesCount()
+{
+    this->_entitiesCount = 0;
+}
+
+/**
  * @brief Get all registered systems
  *
  * @return std::vector<std::function<void(Registry&, double)>>&


### PR DESCRIPTION
This pull request adds a new method to the `Registry` class that allows you to reset the count of entities to zero. This update provides more control over entity management, especially useful for cases like resetting game state or reinitializing the registry.

Entity management improvements:

* Added the `resetEntitiesCount()` method to the `Registry` class in `Registry.hpp`, enabling the entity count to be reset to zero.
* Implemented the `resetEntitiesCount()` method in `Registry.cpp`, which sets `_entitiesCount` back to zero.